### PR TITLE
怪兽 英雄 升级 ai数组

### DIFF
--- a/Classes/Entity/Monster/Monsters/DesertMonster.cpp
+++ b/Classes/Entity/Monster/Monsters/DesertMonster.cpp
@@ -49,7 +49,7 @@ void DesertMonster::initMonster(int maxHealthPoint, int attack, int defence, flo
 ****************************/
 void DesertMonster::initMonster()
 {
-	_panel.init(2000, 0, 100, 0.0f, 0.0f, 0);
+	_panel.init(1000, 100, 100, 1.0f, 1.0f, 100);
 }
 void DesertMonster::keepHealthBar(Slider* healthBar)
 {

--- a/Classes/Entity/Monster/Monsters/GroundMonster.cpp
+++ b/Classes/Entity/Monster/Monsters/GroundMonster.cpp
@@ -49,7 +49,7 @@ void GroundMonster::initMonster(int maxHealthPoint, int attack, int defence, flo
 ****************************/
 void GroundMonster::initMonster()
 {
-	_panel.init(3000, 0, 200, 0.0f, 0.0f, 0);
+	_panel.init(1000, 100, 200, 1.0f, 1.0f, 100);
 }
 void GroundMonster::keepHealthBar(Slider* healthBar)
 {

--- a/Classes/Entity/Monster/Monsters/WaterMonster.cpp
+++ b/Classes/Entity/Monster/Monsters/WaterMonster.cpp
@@ -49,7 +49,7 @@ void WaterMonster::initMonster(int maxHealthPoint, int attack, int defence, floa
 ****************************/
 void WaterMonster::initMonster()
 {
-	_panel.init(1000, 0, 100, 0.0f, 0.0f, 0);
+	_panel.init(600, 100, 100, 1.0f, 1.0f, 100);
 }
 void WaterMonster::keepHealthBar(Slider* healthBar)
 {

--- a/Classes/Entity/Player/Hero/Hero2.h
+++ b/Classes/Entity/Player/Hero/Hero2.h
@@ -48,7 +48,7 @@ using namespace cocos2d;
 #define HERO2_LEVELTEXT_POSITION Vec2(this->getPosition().x, this->getPosition().y + HERO2_YOU_BAR_POSITION + bar->getContentSize().height)
 //初始面板
 #define HERO2_INIT_MAXHEALTHPOINT 1050
-#define HERO2_INIT_ATTACK 130
+#define HERO2_INIT_ATTACK 140
 #define HERO2_INIT_DEFENCE 150
 #define HERO2_INIT_SKILLRATE 2.7f
 #define HERO2_INIT_ATTACKRATE 1.2f

--- a/Classes/Entity/Player/Hero/Hero3.h
+++ b/Classes/Entity/Player/Hero/Hero3.h
@@ -51,8 +51,8 @@ using namespace cocos2d;
 #define HERO3_INIT_MAXHEALTHPOINT 800
 #define HERO3_INIT_ATTACK 130
 #define HERO3_INIT_DEFENCE 90
-#define HERO3_INIT_SKILLRATE 3.5f
-#define HERO3_INIT_ATTACKRATE 0.6f
+#define HERO3_INIT_SKILLRATE 3.9f
+#define HERO3_INIT_ATTACKRATE 0.8f
 
 /*==============================!!!!!“‘…œ∫Í«ÎŒ–ﬁ∏ƒ!!!!!=================================*/
 class Hero1;

--- a/Classes/Entity/Player/Panel.cpp
+++ b/Classes/Entity/Player/Panel.cpp
@@ -164,7 +164,11 @@ void Panel::setMagicPoint(int magicPoint)
 ****************************/
 void Panel::setAttack(int attack)
 {
-	_attack = attack % (PANEL_MAX_ATTACK + 1);
+	_attack = attack;
+	if (_attack > PANEL_MAX_ATTACK)
+	{
+		_attack = PANEL_MAX_ATTACK;
+	}
 }
 /****************************
 * Name ：Panel::setDefence
@@ -173,7 +177,11 @@ void Panel::setAttack(int attack)
 ****************************/
 void Panel::setDefence(int defence)
 {
-	_defence = defence % (PANEL_MAX_DEFENCE + 1);
+	_defence = defence;
+	if (_defence > PANEL_MAX_DEFENCE)
+	{
+		_defence = PANEL_MAX_DEFENCE;
+	}
 }
 /****************************
 * Name ：Panel::setAttackRate
@@ -263,7 +271,10 @@ int Panel::hit(int attack)
 int Panel::treat(int healthPoint)
 {
 	_healthPoint += healthPoint;
-	_healthPoint %= (_maxHealthPoint + 1);//避免溢出
+	if (_healthPoint > _maxHealthPoint)
+	{
+		_healthPoint = _maxHealthPoint;//避免溢出
+	}
 	return healthPoint;//返回治疗量
 }
 /****************************

--- a/Classes/Entity/Player/Player.h
+++ b/Classes/Entity/Player/Player.h
@@ -101,6 +101,7 @@ public:
 
     virtual bool playerCollisionTest1(Player* target, Weapon* weapon);
     virtual bool playerCollisionTest2(Player* target, Weapon* weapon);
+
     virtual void upgrade(cocos2d::Label* levelText, Slider* bar);
 
 

--- a/Classes/Scene/Game/GameScene.cpp
+++ b/Classes/Scene/Game/GameScene.cpp
@@ -115,6 +115,7 @@ bool GameScene::init()
 	this->addChild(MapLayer1, 0);
 
 	/*=====================创建背景音乐开始=======================*/
+	CocosDenshion::SimpleAudioEngine::getInstance()->preloadBackgroundMusic("music/retro_fight_ingame_01.mp3");
 	if (CocosDenshion::SimpleAudioEngine::sharedEngine()->isBackgroundMusicPlaying())
 	{
 		CocosDenshion::SimpleAudioEngine::getInstance()->playBackgroundMusic("music/retro_fight_ingame_01.mp3", true);

--- a/Classes/Scene/Game/MapLayer.cpp
+++ b/Classes/Scene/Game/MapLayer.cpp
@@ -161,14 +161,14 @@ bool MapLayer::init()
 	// 选择游戏人数
 	// 后续容器大小更改未处理
 
-	for (int i = 1; i <= MAP_AI_NUMBER; ++i)
+	for (int i = 1; i <= AINumber; ++i)
 	{
 		std::string aiNumber = "ai" + std::to_string(i);
 		_aiX[i] = _tileMap->getObjectGroup("AI")->getObject(aiNumber).at("x").asInt();
 		_aiY[i] = _tileMap->getObjectGroup("AI")->getObject(aiNumber).at("y").asInt();
 	}
 
-	for (int i = 1; i <= MAP_AI_NUMBER; ++i)
+	for (int i = 1; i <= AINumber; ++i)
 	{
 		int tempHeroType = rand() % 4;
 		//log("tempHeroType %d", tempHeroType);
@@ -875,7 +875,6 @@ void MapLayer::createHero(Hero** hero, Weapon** weapon, Slider** healthBar, Slid
 * Summary ：初始化怪兽
 * return ：
 ****************************/
-
 template<typename Monsters>
 void MapLayer::createMonster(Monsters** monster, Slider** healthBar,
 	Vec2& position, const std::string& filenameMonster)
@@ -1213,6 +1212,7 @@ void MapLayer::updateAIMove(float delta)
 		if (AI_PLAYER(i)->_panel.getIsSurvive())
 		{
 			updateAIMoveOne(CHARACTER(i));
+			setCharacterVisible(true, CHARACTER(i));
 			++tempNum;
 		}
 		else
@@ -1581,7 +1581,7 @@ void MapLayer::getDefenceBuff(Character& character)
 
 /****************************
 * Name ：MapLayer::setCharacterVisible
-* Summary ：角色不可见
+* Summary ：角色可见状态设置
 * return ：
 ****************************/
 void MapLayer::setCharacterVisible(bool visible, Character& character)

--- a/Classes/Scene/MainMenu/MainMenuScene.cpp
+++ b/Classes/Scene/MainMenu/MainMenuScene.cpp
@@ -232,7 +232,7 @@ bool MainMenuScene::init()
     auto playerMassageMenu = Menu::create(playerMassageItem, NULL);
     playerMassageMenu->setPosition(Vec2::ZERO);
     this->addChild(playerMassageMenu, 2);
-    /*=====================创建玩家信息按钮开始===================*/
+    /*=====================创建玩家信息按钮结束===================*/
 
     return true;
 }
@@ -322,7 +322,11 @@ void MainMenuScene::menuSettingsCallback(cocos2d::Ref* pSender)
     auto settingsScene = SettingsScene::createScene();
     Director::getInstance()->replaceScene(TransitionSlideInR::create(0.5f, settingsScene));//mainmenu未被释放 使用popScene返回
 }
-
+/****************************
+* Name ：MainMenuScene::playerMassageCallback
+* Summary ：玩家信息按钮回调
+* return ：
+****************************/
 void MainMenuScene::playerMassageCallback(cocos2d::Ref* pSender)
 {
     log("_winTimes %d", getUserInt("_winTimes"));
@@ -346,11 +350,20 @@ void MainMenuScene::onEnterTransitionDidFinish()
     system->setPosition(Vec2(visibleSize.width / 2, visibleSize.height));
     this->addChild(system, 5);
 }
-
+/****************************
+* Name ：MainMenuScene::getUserInt
+* Summary ：获取int用户数据
+* return ：
+****************************/
 int MainMenuScene::getUserInt(const char* name)
 {
     return UserDefault::getInstance()->getIntegerForKey(name);
 }
+/****************************
+* Name ：MainMenuScene::setUserInt
+* Summary ：设置int用户数据
+* return ：
+****************************/
 void MainMenuScene::setUserInt(const char* name, int num)
 {
     UserDefault::getInstance()->setIntegerForKey(name, num);

--- a/Classes/Scene/Options/HeroScene.cpp
+++ b/Classes/Scene/Options/HeroScene.cpp
@@ -186,20 +186,22 @@ bool HeroScene::init()
 
    //如果玩家已经选择了英雄，那么优先展示该英雄的动画
        _selectedHero = UserDefault::getInstance()->getIntegerForKey("selectedHero");
-    if (_selectedHero) {
-        switch (_selectedHero) {
-        case 1:
-            animate1();
-            break;
-        case 2:
-            animate2();
-            break;
-        case 3:
-            animate3();
-            break;
-        case 4:
-            animate4();
-            break;
+    if (_selectedHero) 
+    {
+        switch (_selectedHero)
+        {
+            case 1:
+                animate1();
+                break;
+            case 2:
+                animate2();
+                break;
+            case 3:
+                animate3();
+                break;
+            case 4:
+                animate4();
+                break;
         }
         _confirmButton->setEnabled(false);
     }
@@ -240,7 +242,8 @@ void HeroScene::selectHero1Callback(cocos2d::Ref* pSender)
     else
         _confirmButton->setEnabled(true);
 
-    if (_chooseNumber != 1) {
+    if (_chooseNumber != 1)
+    {
 
         if (hero2 != nullptr)
             hero2->setVisible(false);
@@ -264,7 +267,8 @@ void HeroScene::selectHero2Callback(cocos2d::Ref* pSender)
     else
         _confirmButton->setEnabled(true);
 
-    if (_chooseNumber != 2) {
+    if (_chooseNumber != 2)
+    {
 
         if (hero1 != nullptr)
             hero1->setVisible(false);
@@ -286,7 +290,8 @@ void HeroScene::selectHero3Callback(cocos2d::Ref* pSender)
         _confirmButton->setEnabled(false);
     else
         _confirmButton->setEnabled(true);
-    if (_chooseNumber != 3) {
+    if (_chooseNumber != 3)
+    {
 
         if (hero1 != nullptr)
             hero1->setVisible(false);
@@ -309,7 +314,8 @@ void HeroScene::selectHero4Callback(cocos2d::Ref* pSender)
         _confirmButton->setEnabled(false);
     else
         _confirmButton->setEnabled(true);
-    if (_chooseNumber != 4) {
+    if (_chooseNumber != 4)
+    {
         if (hero1 != nullptr)
             hero1->setVisible(false);
         if (hero2 != nullptr)
@@ -332,19 +338,20 @@ void HeroScene::selectHero4Callback(cocos2d::Ref* pSender)
 void HeroScene::selectHeroConfirmCallback(cocos2d::Ref* pSender)
 {
     CocosDenshion::SimpleAudioEngine::getInstance()->playEffect("music/if_click_buttom_on_menu.mp3");
-    switch (_chooseNumber) {
-    case 1:
-        UserDefault::getInstance()->setIntegerForKey("selectedHero", 1);
-        break;
-    case 2:
-        UserDefault::getInstance()->setIntegerForKey("selectedHero", 2);
-        break;
-    case 3:
-        UserDefault::getInstance()->setIntegerForKey("selectedHero", 3);
-        break;
-    case 4:
-        UserDefault::getInstance()->setIntegerForKey("selectedHero", 4);
-        break;
+    switch (_chooseNumber) 
+    {
+        case 1:
+            UserDefault::getInstance()->setIntegerForKey("selectedHero", 1);
+            break;
+        case 2:
+            UserDefault::getInstance()->setIntegerForKey("selectedHero", 2);
+            break;
+        case 3:
+            UserDefault::getInstance()->setIntegerForKey("selectedHero", 3);
+            break;
+        case 4:
+            UserDefault::getInstance()->setIntegerForKey("selectedHero", 4);
+            break;
     }
     _selectedHero= UserDefault::getInstance()->getIntegerForKey("selectedHero");
     _confirmButton->setEnabled(false);


### PR DESCRIPTION
怪兽削弱
英雄数值调整
升级bug修复：调整了treat的结算 调整了对attack、defence的set的结算
ai数组的创建修改为依赖玩家选择
代码风格修正 注释补充